### PR TITLE
To not consider URL as relative path (#10)

### DIFF
--- a/fvcore/common/config.py
+++ b/fvcore/common/config.py
@@ -78,7 +78,7 @@ class CfgNode(_CfgNode):
             base_cfg_file = cfg[BASE_KEY]
             if base_cfg_file.startswith("~"):
                 base_cfg_file = os.path.expanduser(base_cfg_file)
-            if not base_cfg_file.startswith("/"):
+            if not any(map(base_cfg_file.startswith, ["/", "https://", "http://"])):
                 # the path to base cfg is relative to the config file itself.
                 base_cfg_file = os.path.join(
                     os.path.dirname(filename), base_cfg_file


### PR DESCRIPTION
Summary:
when giving an url as base_path, it is considered as relative path, and appends the dirname of the config file to it.

This is a fix to that
Pull Request resolved: https://github.com/facebookresearch/fvcore/pull/10

Differential Revision: D18392351

Pulled By: ppwwyyxx

fbshipit-source-id: b5aa3a8cac6eeab4992b6d26465c84c79274aad2